### PR TITLE
Add timezone support to API command

### DIFF
--- a/civicrm.php
+++ b/civicrm.php
@@ -21,6 +21,9 @@ if (!defined('CIVICRM_WPCLI_LOADED')) {
          * wp civicrm api
          * ===============
          * Command for accessing CiviCRM APIs. Syntax is identical to drush cvap.
+         * Options:
+         * --timezone      Specify a timezone (e.g. --timezone=America/New_York.  Use this with Job.execute to override PHP's timezone, which is UTC.
+         *                 Find a list of PHP timezones here: http://php.net/manual/en/timezones.php
          *
          * wp civicrm cache-clear
          * ===============
@@ -173,6 +176,8 @@ if (!defined('CIVICRM_WPCLI_LOADED')) {
             }
 
             civicrm_initialize();
+            $timezone = $this->getOption('timezone', 'UTC');
+            date_default_timezone_set($timezone);
             $result = civicrm_api($entity, $action, $params);
 
             switch ($this->getOption('out', 'pretty')) {

--- a/civicrm.php
+++ b/civicrm.php
@@ -22,7 +22,7 @@ if (!defined('CIVICRM_WPCLI_LOADED')) {
          * ===============
          * Command for accessing CiviCRM APIs. Syntax is identical to drush cvap.
          * Options:
-         * --timezone      Specify a timezone (e.g. --timezone=America/New_York.  Use this with Job.execute to override PHP's timezone, which is UTC.
+         * --timezone      Specify a timezone (e.g. --timezone=America/New_York.  Use this with Job.execute to override PHP's timezone_string.
          *                 Find a list of PHP timezones here: http://php.net/manual/en/timezones.php
          *
          * wp civicrm cache-clear
@@ -176,7 +176,7 @@ if (!defined('CIVICRM_WPCLI_LOADED')) {
             }
 
             civicrm_initialize();
-            $timezone = $this->getOption('timezone', 'UTC');
+            $timezone = $this->getOption('timezone', get_option('timezone_string'));
             date_default_timezone_set($timezone);
             $result = civicrm_api($entity, $action, $params);
 


### PR DESCRIPTION
I was having trouble using "wp civicrm api job.execute", because Wordpress overrides PHP's timezone settings.  While CiviCRM GUI gets the correct timezone from an override in wp-settings.php, the CiviCRM called via wp-cli gets UTC as the timezone.

To account for this, I've added support for a new option, "--timezone", to your code.  I can imagine you might want to refactor such that this is a global option - but then again, maybe not.  I'm open to feedback for improving this!